### PR TITLE
Update install.sh to install specific versions of the babel packages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,9 @@
 cd ./src/esprima/ && npm i && cd -;
 npm install \
-    @babel/core \
-    @babel/cli \
-    @babel/preset-env \
-    @babel/preset-typescript \
+    @babel/core@7.15.5 \
+    @babel/cli@7.15.7 \
+    @babel/preset-env@7.15.6 \
+    @babel/preset-typescript@7.15.0 \
     mocha;
 python3 -m pip install -r ./requirements.txt;
 


### PR DESCRIPTION
After following INSTALL.md to do a fresh install on a VM with Ubuntu 20.04, we get an error when running `python3 odgen_test.py` due to the following error:

```
.{ Error: Cannot find module '@babel/plugin-proposal-class-properties'
- Did you mean "@babel/plugin-transform-class-properties"?

Make sure that all the Babel plugins and presets you are using
are defined as dependencies or devDependencies in your package.json
file. It's possible that the missing plugin is loaded by a preset
you are using that forgot to add the plugin to its dependencies: you
can workaround this problem by explicitly adding the missing package
to your top-level package.json.
```

This is due to `npm` installing the latest versions of the `@babel` packages (7.23.x), which are about 2.5 years ahead of the versions (7.15.x) used at the time of publication of ODGen.

Updating the `install.sh` script to install specific versions of the `@babel` packages resolves this issue.